### PR TITLE
remove ":" character for completionItem.insertText

### DIFF
--- a/src/completion-item-provider.ts
+++ b/src/completion-item-provider.ts
@@ -195,7 +195,7 @@ export function getProperties(cssSchema, currentWord:string) : CompletionItem[] 
   return cssSchema.data.css.properties.map(property => {
     const completionItem = new CompletionItem(property.name);
 
-    completionItem.insertText = property.name + ': ';
+    completionItem.insertText = property.name + ' ';
     completionItem.detail = property.desc;
     completionItem.kind = CompletionItemKind.Property;
 


### PR DESCRIPTION
In keeping with the 'pure' Stylus style (and most other Stylus plugins), colon on autocompletes should be removed.
