### PR TITLE
fix(decoration): Decorations should be set unconditionally

### DIFF
--- a/src/color-decorators.ts
+++ b/src/color-decorators.ts
@@ -101,9 +101,7 @@ export function updateDecorators(colorsDecorationType, editor) {
     };
   }).slice(0, MAX_DECORATORS);
 
-  if (decorations && decorations.length) {
-    editor.setDecorations(colorsDecorationType, decorations as any);
-  }
+  editor.setDecorations(colorsDecorationType, decorations as any);
 }
 
 export const findEditorByDocument = document =>


### PR DESCRIPTION
Currently, when there is the last decoration on screen and you remove the associated color, you will find the decoration still exist in document, but it should be removed.

This is because when `decorations` changed from an array with elements to an empty array, the `setDecorations` method will not be triggered, until it has elements again, and caused this issue.

I believe remove the if clause can fix this issue without any potential risk.

Please take a look, thanks