### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,11 @@ import CompletionProvider from './completion-item-provider';
 import { StylusDocumentSimbolsProvider } from './symbols-provider';
 import { activateColorDecorations } from './color-decorators';
 
+const DOCUMENT_SELECTOR = {
+  language: 'stylus',
+  scheme: 'file'
+};
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -15,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('languageStylus');
   const completionItemProvider = new CompletionProvider();
   const completionProviderDisposable = vscode.languages
-    .registerCompletionItemProvider('stylus', completionItemProvider, '\\.', '$', '-', '&', '@');
+    .registerCompletionItemProvider(DOCUMENT_SELECTOR, completionItemProvider, '\\.', '$', '-', '&', '@');
   context.subscriptions.push(completionProviderDisposable);
 
   vscode.languages.setLanguageConfiguration('stylus', {
@@ -45,7 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const symbolsProvider = new StylusDocumentSimbolsProvider();
-  const symbolsProviderDisposable = vscode.languages.registerDocumentSymbolProvider('stylus', symbolsProvider);
+  const symbolsProviderDisposable = vscode.languages.registerDocumentSymbolProvider(DOCUMENT_SELECTOR, symbolsProvider);
   context.subscriptions.push(symbolsProviderDisposable);
 
   if (editorConfig.get('colorDecorators')) {


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Stylus, this PR simply updates language services to be local files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a project using Live Share, and doesn't have this extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Stylus extension installed. Additionally, this wouldn't impact the "local" Stylus development experience.