### PR TITLE
chore: improve stylus css grammer highlight

### DIFF
--- a/syntaxes/stylus.json
+++ b/syntaxes/stylus.json
@@ -625,13 +625,13 @@
     "at_rule": {
       "patterns": [
         {
-          "begin": "\\s*(@)(import|require)\\b\\s*",
+          "begin": "\\s*((@)(import|require))\\b\\s*",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.import.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.import.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "end": "\\s*((?=;|$|\\n))",
@@ -648,13 +648,13 @@
           ]
         },
         {
-          "begin": "\\s*(@)(extend[s]?)\\b\\s*",
+          "begin": "\\s*((@)(extend[s]?)\\b)\\s*",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.extend.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.extend.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "end": "\\s*((?=;|$|\\n))",
@@ -671,37 +671,38 @@
           ]
         },
         {
-          "match": "^\\s*(@)(font-face)\\b",
+          "match": "^\\s*((@)font-face)\\b",
           "captures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.fontface.stylus"
+            
             },
             "2": {
-              "name": "keyword.control.at-rule.fontface.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "name": "meta.at-rule.fontface.stylus"
         },
         {
-          "match": "^\\s*(@)(css)\\b",
+          "match": "^\\s*((@)css)\\b",
           "captures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.css.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.css.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "name": "meta.at-rule.css.stylus"
         },
         {
-          "begin": "\\s*(@)(charset)\\b\\s*",
+          "begin": "\\s*((@)charset)\\b\\s*",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.charset.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.charset.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "end": "\\s*((?=;|$|\\n))",
@@ -713,13 +714,13 @@
           ]
         },
         {
-          "begin": "\\s*(@)(keyframes)\\b\\s+([a-zA-Z_-][a-zA-Z0-9_-]*)",
+          "begin": "\\s*((@)keyframes)\\b\\s+([a-zA-Z_-][a-zA-Z0-9_-]*)",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.keyframes.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.keyframes.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             },
             "3": {
               "name": "entity.name.function.keyframe.stylus"
@@ -740,13 +741,13 @@
           ]
         },
         {
-          "match": "^\\s*(@)(media)\\b",
+          "match": "^\\s*((@)media)\\b",
           "captures": {
             "1": {
-              "name": "punctuation.definition.keyword.stylus"
+              "name": "keyword.control.at-rule.media.stylus"
             },
             "2": {
-              "name": "keyword.control.at-rule.media.stylus"
+              "name": "punctuation.definition.keyword.stylus"
             }
           },
           "name": "meta.at-rule.media.stylus"


### PR DESCRIPTION
Modified `syntaxes/stylus.json` to improve stylus css grammer highlight

Before:
![2021-08-25 09 40 33](https://user-images.githubusercontent.com/14012511/130712579-4ef03734-4bc7-4c6f-a06f-291a1ac3dd0d.png)

After:
![2021-08-25 09 41 14](https://user-images.githubusercontent.com/14012511/130712599-60e8ca00-8446-4311-9478-317b26294d72.png)

VSCode version: 1.59.1

cc @d4rkr00t , Ready for code review. 

