### PR TITLE
chore: upgrade stylus version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,14 +1052,13 @@
             }
         },
         "css": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+            "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
             "requires": {
-                "inherits": "^2.0.3",
+                "inherits": "^2.0.4",
                 "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
+                "source-map-resolve": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -1067,14 +1066,6 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
-            }
-        },
-        "css-parse": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-            "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-            "requires": {
-                "css": "^2.0.0"
             }
         },
         "currently-unhandled": {
@@ -2965,11 +2956,6 @@
                 "global-dirs": "^0.1.1"
             }
         },
-        "resolve-url": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-        },
         "responselike": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -3053,21 +3039,13 @@
             "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         },
         "source-map-resolve": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+            "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
             "requires": {
                 "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "decode-uri-component": "^0.2.0"
             }
-        },
-        "source-map-url": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-            "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
         },
         "spdx-correct": {
             "version": "3.1.1",
@@ -3186,11 +3164,11 @@
             "dev": true
         },
         "stylus": {
-            "version": "0.54.8",
-            "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.8.tgz",
-            "integrity": "sha512-vr54Or4BZ7pJafo2mpf0ZcwA74rpuYCZbxrHBsH8kbcXOwSfvBFwsRfpGO5OD5fhG5HDCFW737PKaawI7OqEAg==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.55.0.tgz",
+            "integrity": "sha512-MuzIIVRSbc8XxHH7FjkvWqkIcr1BvoMZoR/oFuAJDlh7VSaNJzrB4uJ38GRQa+mWjLXODAMzeDe0xi9GYbGwnw==",
             "requires": {
-                "css-parse": "~2.0.0",
+                "css": "^3.0.0",
                 "debug": "~3.1.0",
                 "glob": "^7.1.6",
                 "mkdirp": "~1.0.4",
@@ -3335,11 +3313,6 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
-        },
-        "urix": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "url-parse-lax": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         }
     },
     "dependencies": {
-        "stylus": "0.54.8",
+        "stylus": "^0.55.0",
         "vscode-css-languageservice": "^5.1.4"
     }
 }


### PR DESCRIPTION
I released stylus [v0.55.0](https://www.npmjs.com/package/stylus/v/0.55.0) just now, so sync with language-stylus.

cc @d4rkr00t 